### PR TITLE
Remoção de suporte à plataforma x64_mingw.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]
 
 #Autenticação
 gem 'devise'


### PR DESCRIPTION
Modificação da linha 44 de "gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]" para "gem 'tzinfo-data', platforms: [:mingw, :mswin, :jruby]" (remoção de " :x64_mingw,").